### PR TITLE
Correct usage of Enumerable.Range

### DIFF
--- a/src/FizzBuzzer/FizzBuzz.cs
+++ b/src/FizzBuzzer/FizzBuzz.cs
@@ -22,7 +22,7 @@ namespace FizzBuzzer
 
         public IEnumerable<string> ShakeIt()
         {
-            return Enumerable.Range(MinValue, MaxValue).Select(FizzOrBuzz);
+            return Enumerable.Range(MinValue, MaxValue - MinValue + 1).Select(FizzOrBuzz);
         }
 
         public string FizzOrBuzz(int number)


### PR DESCRIPTION
2nd param is count, not max value (see https://msdn.microsoft.com/en-us/library/system.linq.enumerable.range(v=vs.110).aspx)

fixes #1
